### PR TITLE
adjusted setup.py to accommodate SR changes to the include locations …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['pandas', 'cython', 'h5py']

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ elif sys.platform.startswith('win32'):
             'libraries': lib_names
             }
 else:  # linux, unix, cygwin
-    args = {'include_dirs': [numpy.get_include(), 'include/'],
+    args = {'include_dirs': [numpy.get_include(), 'include/', '/usr/include/EyeLink/'],
             'library_dirs': ['lib/'],
             'libraries': ['edfapi'],
             'extra_compile_args': ['-fopenmp'],


### PR DESCRIPTION
I recently pulled the latest revisions of SR's SDK and found that pyedfread would no longer build. Seems SR changed the location of the necessary includes from `/usr/include` to `/usr/include/EyeLink`. This change fixes this and allows pyedfread to build and work properly on linux.

Tested on Ubuntu 18.04 and 20.04.