### PR TITLE
Updated libraries path for Linux, included build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
-[build-system]
+[dependencies]
 requires = ['pandas', 'cython', 'h5py']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
-[dependencies]
-requires = ['pandas', 'cython', 'h5py']
+[build-system]
+requires = ["cython", "setuptools", "wheel", "numpy", "pandas"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['pandas', 'cython', 'h5py']

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ elif sys.platform.startswith('win32'):
             'libraries': lib_names
             }
 else:  # linux, unix, cygwin
-    args = {'include_dirs': [numpy.get_include(), 'include/'],
+    args = {'include_dirs': [numpy.get_include(), 'include/', '/usr/include/EyeLink/'],
             'library_dirs': ['lib/'],
             'libraries': ['edfapi'],
             'extra_compile_args': ['-fopenmp'],


### PR DESCRIPTION
SR appears to have changed the location to which the SDK installs include files for building pyedfead. This updates setup.py to account for this.

I also added pyproject.toml to include build dependencies, should help with gathering requirements during build.