### PR TITLE
Fix length of samples (num_elements to cnt), fix types of samples dataframe, add ftime option

### DIFF
--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -333,4 +333,7 @@ def parse_edf(
                 data, sample_type, trial, current_event, event_accumulator
             )
     free(buf)
+    # num_elements contained number of combined samples, messages, and events. This truncates
+    # to only number of samples read (cnt).
+    samples = samples[:cnt, :]; 
     return samples, event_accumulator, message_accumulator

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -335,5 +335,5 @@ def parse_edf(
     free(buf)
     # num_elements contained number of combined samples, messages, and events. This truncates
     # to only number of samples read (cnt).
-    samples = samples[:cnt]; 
+    samples = samples[:cnt, :]; 
     return samples, event_accumulator, message_accumulator

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -333,4 +333,7 @@ def parse_edf(
                 data, sample_type, trial, current_event, event_accumulator
             )
     free(buf)
+    # num_elements contained number of combined samples, messages, and events. This truncates
+    # to only number of samples read (cnt).
+    samples = samples[:cnt]; 
     return samples, event_accumulator, message_accumulator

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -386,7 +386,7 @@ def samples_to_ftime(samples):
         raise Exception("ERROR: flags should be of unsigned integer type for bitwise and to work properly")
     samples['_halfms'] = (0 != (bitmask & samples['flags']));
     samples['time'] = samples['time'].astype(np.float64);
-    s.loc[ (True==s['_halfms']), 'time' ] += HALFMS;
+    samples.loc[ (True==s['_halfms']), 'time' ] += HALFMS;
     
     # Drop temporary _halfms column
     samples = samples[ [a for a in samples.columns if a is not '_halfms' ] ];

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -386,7 +386,7 @@ def samples_to_ftime(samples):
         raise Exception("ERROR: flags should be of unsigned integer type for bitwise and to work properly")
     samples['_halfms'] = (0 != (bitmask & samples['flags']));
     samples['time'] = samples['time'].astype(np.float64);
-    samples.loc[ (True==s['_halfms']), 'time' ] += HALFMS;
+    samples.loc[ (True==samples['_halfms']), 'time' ] += HALFMS;
     
     # Drop temporary _halfms column
     samples = samples[ [a for a in samples.columns if a is not '_halfms' ] ];

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -364,9 +364,61 @@ def parse_edf(
 
         if not ignore_samples and (sample_type == SAMPLE_TYPE):
             fd = edf_get_float_data(ef)
-            samples = parse_sample(fd, cnt, samples);
-            cnt += 1
+            #samples = parse_sample(fd, cnt, samples);
 
+            # We may have to re-order sorted dict order into
+            # sample_columns before returning DF if we care.
+            
+            samples['time'][cnt] = fd.fs.time; #0
+            samples['px_left'][cnt] = float(fd.fs.px[0]); #1
+            samples['px_right'][cnt] = float(fd.fs.px[1]); #2
+            samples['py_left'][cnt] = float(fd.fs.py[0]); #3
+            samples['py_right'][cnt] = float(fd.fs.py[1]); #4
+            samples['hx_left'][cnt] = float(fd.fs.hx[0]); #5
+            samples['hx_right'][cnt] = float(fd.fs.hx[1]); #6
+            samples['hy_left'][cnt] = float(fd.fs.hy[0]); #7
+            samples['hy_right'][cnt] = float(fd.fs.hy[1]); #8
+            samples['pa_left'][cnt] = float(fd.fs.pa[0]); #9
+            samples['pa_right'][cnt] = float(fd.fs.pa[1]); #10
+            samples['gx_left'][cnt] = float(fd.fs.gx[0]); #11
+            samples['gx_right'][cnt] = float(fd.fs.gx[1]); #12
+            samples['gy_left'][cnt] = float(fd.fs.gy[0]); #13
+            samples['gy_right'][cnt] = float(fd.fs.gy[1]); #14
+            samples['rx'][cnt] = float(fd.fs.rx); #15
+            samples['ry'][cnt] = float(fd.fs.ry); #16
+            samples['gxvel_left'][cnt] = float(fd.fs.gxvel[0]); #17
+            samples['gxvel_right'][cnt] = float(fd.fs.gxvel[1]); #18
+            samples['gyvel_left'][cnt] = float(fd.fs.gyvel[0]); #19
+            samples['gyvel_right'][cnt] = float(fd.fs.gyvel[1]); #20
+            samples['hxvel_left'][cnt] = float(fd.fs.hxvel[0]); #21
+            samples['hxvel_right'][cnt] = float(fd.fs.hxvel[1]); #22
+            samples['hyvel_left'][cnt] = float(fd.fs.hyvel[0]); #23
+            samples['hyvel_right'][cnt] = float(fd.fs.hyvel[1]); #24
+            samples['rxvel_left'][cnt] = float(fd.fs.rxvel[0]); #25
+            samples['rxvel_right'][cnt] = float(fd.fs.rxvel[1]); #26
+            samples['ryvel_left'][cnt] = float(fd.fs.ryvel[0]); #27
+            samples['ryvel_right'][cnt] = float(fd.fs.ryvel[1]); #28
+            
+            ## REV: These are all accessing 0th element for some reason
+            samples['fgxvel'][cnt] = float(fd.fs.fgxvel[0]); #29
+            samples['fgyvel'][cnt] = float(fd.fs.fgyvel[0]); #30
+            samples['fhxvel'][cnt] = float(fd.fs.fhxvel[0]); #31
+            samples['fhyvel'][cnt] = float(fd.fs.fhyvel[0]); #32
+            samples['frxvel'][cnt] = float(fd.fs.frxvel[0]); #33
+            samples['fryvel'][cnt] = float(fd.fs.fryvel[0]); #34
+            
+            # samples[cnt, 39:48] =  <float>fd.fs.hdata # head-tracker data
+            # (not prescaled)
+            
+            samples['flags'][cnt] = fd.fs.flags; #35
+            samlpes['input'][cnt] = fd.fs.input; #36 # extra (input word)
+            samples['buttons'][cnt] = fd.fs.buttons  #37 # button state & changes
+            samples['htype'][cnt] = fd.fs.htype; #38  # head-tracker data type
+            samples['errors'][cnt] = fd.fs.errors; #39
+            
+            cnt += 1;
+            pass;
+        
         elif sample_type == MESSAGEEVENT:
             data = data2dict(sample_type, ef)
             trial = parse_message(

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -254,78 +254,6 @@ def create_sample_array_memory(num_elements):
     # be fixed to address new API/capabilities.
     return mydict;
 
-def parse_sample(fd, cnt, samples):
-    """
-    REV: sets a single row of "samples" by setting the "cnt"th
-    row in each 1d array stored in samples dict. Reason to do this
-    over NDARRAY is that each row may have different type
-    (e.g. some are UINT16 flags)
-
-    input:
-    -  fd, the edf_get_float_data(ef) returned struct
-    -  cnt, size_t offset into array to write to
-    -  samples, dict already created by create_sample_array_memory
-    output:
-    -  returns samples with updated values.
-    """
-
-    startsize = len(samples);
-    
-    # We may have to re-order sorted dict order into
-    # sample_columns before returning DF if we care.
-    samples['time'][cnt] = fd.fs.time; #0
-    samples['px_left'][cnt] = float(fd.fs.px[0]); #1
-    samples['px_right'][cnt] = float(fd.fs.px[1]); #2
-    samples['py_left'][cnt] = float(fd.fs.py[0]); #3
-    samples['py_right'][cnt] = float(fd.fs.py[1]); #4
-    samples['hx_left'][cnt] = float(fd.fs.hx[0]); #5
-    samples['hx_right'][cnt] = float(fd.fs.hx[1]); #6
-    samples['hy_left'][cnt] = float(fd.fs.hy[0]); #7
-    samples['hy_right'][cnt] = float(fd.fs.hy[1]); #8
-    samples['pa_left'][cnt] = float(fd.fs.pa[0]); #9
-    samples['pa_right'][cnt] = float(fd.fs.pa[1]); #10
-    samples['gx_left'][cnt] = float(fd.fs.gx[0]); #11
-    samples['gx_right'][cnt] = float(fd.fs.gx[1]); #12
-    samples['gy_left'][cnt] = float(fd.fs.gy[0]); #13
-    samples['gy_right'][cnt] = float(fd.fs.gy[1]); #14
-    samples['rx'][cnt] = float(fd.fs.rx); #15
-    samples['ry'][cnt] = float(fd.fs.ry); #16
-    samples['gxvel_left'][cnt] = float(fd.fs.gxvel[0]); #17
-    samples['gxvel_right'][cnt] = float(fd.fs.gxvel[1]); #18
-    samples['gyvel_left'][cnt] = float(fd.fs.gyvel[0]); #19
-    samples['gyvel_right'][cnt] = float(fd.fs.gyvel[1]); #20
-    samples['hxvel_left'][cnt] = float(fd.fs.hxvel[0]); #21
-    samples['hxvel_right'][cnt] = float(fd.fs.hxvel[1]); #22
-    samples['hyvel_left'][cnt] = float(fd.fs.hyvel[0]); #23
-    samples['hyvel_right'][cnt] = float(fd.fs.hyvel[1]); #24
-    samples['rxvel_left'][cnt] = float(fd.fs.rxvel[0]); #25
-    samples['rxvel_right'][cnt] = float(fd.fs.rxvel[1]); #26
-    samples['ryvel_left'][cnt] = float(fd.fs.ryvel[0]); #27
-    samples['ryvel_right'][cnt] = float(fd.fs.ryvel[1]); #28
-
-    ## REV: These are all accessing 0th element for some reason
-    samples['fgxvel'][cnt] = float(fd.fs.fgxvel[0]); #29
-    samples['fgyvel'][cnt] = float(fd.fs.fgyvel[0]); #30
-    samples['fhxvel'][cnt] = float(fd.fs.fhxvel[0]); #31
-    samples['fhyvel'][cnt] = float(fd.fs.fhyvel[0]); #32
-    samples['frxvel'][cnt] = float(fd.fs.frxvel[0]); #33
-    samples['fryvel'][cnt] = float(fd.fs.fryvel[0]); #34
-    
-    # samples[cnt, 39:48] =  <float>fd.fs.hdata # head-tracker data
-    # (not prescaled)
-    
-    samples['flags'][cnt] = fd.fs.flags; #35
-    samlpes['input'][cnt] = fd.fs.input; #36 # extra (input word)
-    samples['buttons'][cnt] = fd.fs.buttons  #37 # button state & changes
-    samples['htype'][cnt] = fd.fs.htype; #38  # head-tracker data type
-    samples['errors'][cnt] = fd.fs.errors; #39
-
-    if( len(samples) != startsize ):
-        raise Exception("REV: you messed up and typed something wrong in dict names");
-    
-    return samples;
-
-
 def parse_edf(
     filename, ignore_samples=False, message_filter=None, trial_marker='TRIALID'
 ):
@@ -347,7 +275,7 @@ def parse_edf(
         num_elements = 0
 
     
-    create_sample_array_memory(num_elements);
+    samples = create_sample_array_memory(num_elements);
     
     # parse samples and events
     trial = -1
@@ -365,7 +293,7 @@ def parse_edf(
         if not ignore_samples and (sample_type == SAMPLE_TYPE):
             fd = edf_get_float_data(ef)
             #samples = parse_sample(fd, cnt, samples);
-
+	    
             # We may have to re-order sorted dict order into
             # sample_columns before returning DF if we care.
             
@@ -411,7 +339,7 @@ def parse_edf(
             # (not prescaled)
             
             samples['flags'][cnt] = fd.fs.flags; #35
-            samlpes['input'][cnt] = fd.fs.input; #36 # extra (input word)
+            samples['input'][cnt] = fd.fs.input; #36 # extra (input word)
             samples['buttons'][cnt] = fd.fs.buttons  #37 # button state & changes
             samples['htype'][cnt] = fd.fs.htype; #38  # head-tracker data type
             samples['errors'][cnt] = fd.fs.errors; #39

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -66,7 +66,7 @@ def read_edf(
     samples = pd.DataFrame(samples)
     
     if( True == ftime ):
-        samples = edf_read.samples_to_ftimes(samples);
+        samples = edf_read.samples_to_ftime(samples);
         pass;
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -11,6 +11,7 @@ def read_edf(
     ignore_samples=False,
     message_filter=None,
     trial_marker="TRIALID",
+    ftime=False
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -39,6 +40,10 @@ def read_edf(
         Messages that start with this string will be assumed to
         indicate the start of a trial.
 
+    ftime: bool, optional
+        If true, times are converted to floating point (from default int32) and 0.5 msec intervals are added
+        for approriate 2000 hz recordings. Otherwise, int times are simply doubled up for 2k hz recordings.
+
     Returns
     -------
     samples : pandas.DataFrame
@@ -58,7 +63,12 @@ def read_edf(
     )
     events = pd.DataFrame(events)
     messages = pd.DataFrame(messages)
-    samples = pd.DataFrame(np.asarray(samples), columns=edf_read.sample_columns)
+    samples = pd.DataFrame(samples)
+
+    if( True == ftime ):
+        samples = samples_to_ftimes(samples);
+        pass;
+    
     return samples, events, messages
 
 

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -11,7 +11,7 @@ def read_edf(
     ignore_samples=False,
     message_filter=None,
     trial_marker="TRIALID",
-    ftime=False
+    ftime=True
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -40,7 +40,7 @@ def read_edf(
         Messages that start with this string will be assumed to
         indicate the start of a trial.
 
-    ftime: bool, optional
+    ftime: bool, optional (default True)
         If true, times are converted to floating point (from default int32) and 0.5 msec intervals are added
         for approriate 2000 hz recordings. Otherwise, int times are simply doubled up for 2k hz recordings.
 

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -66,7 +66,7 @@ def read_edf(
     samples = pd.DataFrame(samples)
     
     if( True == ftime ):
-        samples = samples_to_ftimes(samples);
+        samples = edf_read.samples_to_ftimes(samples);
         pass;
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -64,11 +64,11 @@ def read_edf(
     events = pd.DataFrame(events)
     messages = pd.DataFrame(messages)
     samples = pd.DataFrame(samples)
-
+    
     if( True == ftime ):
         samples = samples_to_ftimes(samples);
         pass;
-
+    
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)
     samples = samples[ list(edf_read.sample_columns) ];
     

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -68,6 +68,9 @@ def read_edf(
     if( True == ftime ):
         samples = samples_to_ftimes(samples);
         pass;
+
+    ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)
+    samples = samples[ list(edf_read.sample_columns) ];
     
     return samples, events, messages
 


### PR DESCRIPTION
This pull request combines fixes for 3 bugs/features.

1.  Fixes lengths of samples dataframe (as #43)
2. Changes types of samples dataframe columns to their correct types (uint16 where necessary rather than all float64)
3. Adds "ftime" option to read_edf in parse.py (default true), which (a) converts "time" column to float64 and (b) adds 0.5 msec offset based on "flags" column.