### PR TITLE
Velcolfix branch (for velocity columns memory uninitialization? in linux version 4.2.1197)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ elif sys.platform.startswith("win32"):
 else:  # linux, unix, cygwin
     args = {
         "include_dirs": [numpy.get_include(), "include/", '/usr/include/EyeLink/'],
-        "library_dirs": ["lib/"],
+        "library_dirs": ["lib/", "/usr/lib/x86_64-linux-gnu"],
         "libraries": ["edfapi"],
         "extra_compile_args": ["-fopenmp"],
         "extra_link_args": ["-fopenmp"],

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -249,11 +249,11 @@ def create_sample_array_memory(num_elements, flttype=None):
         fltbytes=sizeof(float);
         if(4==sizeof(float)):
             flttype=np.float32;
-            print("\n\n\n\nFLOATS ARE 32\n\n\n\n");
+            #print("\n\n\n\nFLOATS ARE 32\n\n\n\n");
             pass;
         elif(8==sizeof(float)):
             flttype=np.float64;
-            print("\n\n\n\nFLOATS ARE 64\n\n\n\n");
+            #print("\n\n\n\nFLOATS ARE 64\n\n\n\n");
             pass;
         else:
             raise Exception("Unsupported float type on this processor? Bytes in native C float = {}".format(fltbytes));
@@ -322,16 +322,16 @@ def parse_edf(
             fd = edf_get_float_data(ef)
             
             samples['time'][cnt] = fd.fs.time; #0
-            samples['px_left'][cnt] = float(fd.fs.px[0]); #1
-            samples['px_right'][cnt] = float(fd.fs.px[1]); #2
-            samples['py_left'][cnt] = float(fd.fs.py[0]); #3
-            samples['py_right'][cnt] = float(fd.fs.py[1]); #4
-            samples['hx_left'][cnt] = float(fd.fs.hx[0]); #5
-            samples['hx_right'][cnt] = float(fd.fs.hx[1]); #6
-            samples['hy_left'][cnt] = float(fd.fs.hy[0]); #7
-            samples['hy_right'][cnt] = float(fd.fs.hy[1]); #8
-            samples['pa_left'][cnt] = float(fd.fs.pa[0]); #9
-            samples['pa_right'][cnt] = fd.fs.pa[1]; #10   #They stopped with float() cast here, why?
+            samples['px_left'][cnt] = fd.fs.px[0]; #1
+            samples['px_right'][cnt] = fd.fs.px[1]; #2
+            samples['py_left'][cnt] = fd.fs.py[0]; #3
+            samples['py_right'][cnt] = fd.fs.py[1]; #4
+            samples['hx_left'][cnt] = fd.fs.hx[0]; #5
+            samples['hx_right'][cnt] = fd.fs.hx[1]; #6
+            samples['hy_left'][cnt] = fd.fs.hy[0]; #7
+            samples['hy_right'][cnt] = fd.fs.hy[1]; #8
+            samples['pa_left'][cnt] = fd.fs.pa[0]; #9
+            samples['pa_right'][cnt] = fd.fs.pa[1]; #10
             samples['gx_left'][cnt] = fd.fs.gx[0]; #11
             samples['gx_right'][cnt] = fd.fs.gx[1]; #12
             samples['gy_left'][cnt] = fd.fs.gy[0]; #13

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -6,7 +6,7 @@ cimport numpy as np
 import numpy as np
 import string
 
-from libc.stdint cimport int16_t, uint16_t, uint32_t, int64_t
+from libc.stdint cimport int16_t, uint16_t, uint32_t, int64_t, uint64_t
 from libc.stdlib cimport malloc, free
 
 from libc.stdio cimport printf
@@ -236,15 +236,59 @@ def parse_message(data, trial, message_accumulator, message_filter, trial_marker
     return trial
 
 
-def parse_edf(
+
+## REV: numpy type should match system float type used by eyelink... currently usually float32, but python defaults to
+## float64 so may as well use that. Even better would be to "check"
+def create_sample_array_memory(num_elements, flttype=None):
+    #First, just initialize all to float to save time.
+    # Note, num_elements is longer than the maximum that we will
+    # actually hold, so we must be sure to truncate at very end
+    # of parse.
+    
+    if( None==flttype ):
+        fltbytes=sizeof(float);
+        if(4==sizeof(float)):
+            flttype=np.float32;
+            print("\n\n\n\nFLOATS ARE 32\n\n\n\n");
+            pass;
+        elif(8==sizeof(float)):
+            flttype=np.float64;
+            print("\n\n\n\nFLOATS ARE 64\n\n\n\n");
+            pass;
+        else:
+            raise Exception("Unsupported float type on this processor? Bytes in native C float = {}".format(fltbytes));
+        pass;
+    
+    
+    mydict = {  colname : np.ndarray(num_elements, dtype=flttype)  for colname in sample_columns };
+    #Then, reallocate only those which are not float64s...
+    mydict['time'] = np.ndarray(num_elements, dtype=np.uint32);
+    mydict['flags'] = np.ndarray(num_elements, dtype=np.uint16);
+    mydict['input'] = np.ndarray(num_elements, dtype=np.uint16);
+    mydict['buttons'] = np.ndarray(num_elements, dtype=np.uint16);
+    mydict['htype'] = np.ndarray(num_elements, dtype=np.int16);
+    mydict['errors'] = np.ndarray(num_elements, dtype=np.uint16);
+    # mydict['hdata'] is not included but may be added in future
+    # (it is reserved for future use).
+    # REV: We should check that htype is always 0. If not, this must
+    # be fixed to address new API/capabilities.
+    return mydict;
+
+
+
+def parse_edf( 
     filename, ignore_samples=False, message_filter=None, trial_marker='TRIALID'
 ):
-    """Read samples, events, and messages from an EDF file."""
+    """Read samples, events, and messages from an EDF file. REV: version which uses numpy ndarrays in case bitlength of
+    mapping from cdef cython struct matters (probably not)
+
+    Samples type is dict with keys colnames, values are 1-d NDarrays containing (appropriately typed uint32, float64, etc. values).
+    """
     cdef int errval = 1
     cdef char * buf = < char * > malloc(1024 * sizeof(char))
     cdef EDFFILE * ef
     cdef int sample_type, cnt, trial
-
+    
     # open the file
     ef = edf_open_file(filename.encode('utf-8'), 0, 1, 1, & errval)
     if errval < 0:
@@ -255,9 +299,10 @@ def parse_edf(
     num_elements = edf_get_element_count(ef)
     if ignore_samples:
         num_elements = 0
-    cdef np.ndarray npsamples = np.ndarray((num_elements, 40), dtype=np.float64)
-    cdef np.float64_t[:, :] samples = npsamples
+        pass;
 
+    samples = create_sample_array_memory(num_elements);
+        
     # parse samples and events
     trial = -1
     cnt = 0
@@ -272,55 +317,65 @@ def parse_edf(
             break
 
         if not ignore_samples and (sample_type == SAMPLE_TYPE):
+            # fd is a ALLF_DATA type, a union including multiple "views" including .fs view
+            # which means we will access memory offsets according to FSAMPLE struct.
             fd = edf_get_float_data(ef)
-            # Map fields explicitly into memory view
-            samples[cnt, 0] = float(fd.fs.time)
-            samples[cnt, 1] = float(fd.fs.px[0])
-            samples[cnt, 2] = float(fd.fs.px[1])
-            samples[cnt, 3] = float(fd.fs.py[0])
-            samples[cnt, 4] = float(fd.fs.py[1])
-            samples[cnt, 5] = float(fd.fs.hx[0])
-            samples[cnt, 6] = float(fd.fs.hx[1])
-            samples[cnt, 7] = float(fd.fs.hy[0])
-            samples[cnt, 8] = float(fd.fs.hy[1])
-            samples[cnt, 9] = float(fd.fs.pa[0])
-            samples[cnt, 10] = fd.fs.pa[1]
-            samples[cnt, 11] = fd.fs.gx[0]
-            samples[cnt, 12] = fd.fs.gx[1]
-            samples[cnt, 13] = fd.fs.gy[0]
-            samples[cnt, 14] = fd.fs.gy[1]
-            samples[cnt, 15] = fd.fs.rx
-            samples[cnt, 16] = fd.fs.ry
+            
+            samples['time'][cnt] = fd.fs.time; #0
+            samples['px_left'][cnt] = float(fd.fs.px[0]); #1
+            samples['px_right'][cnt] = float(fd.fs.px[1]); #2
+            samples['py_left'][cnt] = float(fd.fs.py[0]); #3
+            samples['py_right'][cnt] = float(fd.fs.py[1]); #4
+            samples['hx_left'][cnt] = float(fd.fs.hx[0]); #5
+            samples['hx_right'][cnt] = float(fd.fs.hx[1]); #6
+            samples['hy_left'][cnt] = float(fd.fs.hy[0]); #7
+            samples['hy_right'][cnt] = float(fd.fs.hy[1]); #8
+            samples['pa_left'][cnt] = float(fd.fs.pa[0]); #9
+            samples['pa_right'][cnt] = fd.fs.pa[1]; #10   #They stopped with float() cast here, why?
+            samples['gx_left'][cnt] = fd.fs.gx[0]; #11
+            samples['gx_right'][cnt] = fd.fs.gx[1]; #12
+            samples['gy_left'][cnt] = fd.fs.gy[0]; #13
+            samples['gy_right'][cnt] = fd.fs.gy[1]; #14
+            samples['rx'][cnt] = fd.fs.rx; #15
+            samples['ry'][cnt] = fd.fs.ry; #16
+            samples['gxvel_left'][cnt] = fd.fs.gxvel[0]; #17
+            samples['gxvel_right'][cnt] = fd.fs.gxvel[1]; #18
+            samples['gyvel_left'][cnt] = fd.fs.gyvel[0]; #19
+            samples['gyvel_right'][cnt] = fd.fs.gyvel[1]; #20
+            samples['hxvel_left'][cnt] = fd.fs.hxvel[0]; #21
+            samples['hxvel_right'][cnt] = fd.fs.hxvel[1]; #22
+            samples['hyvel_left'][cnt] = fd.fs.hyvel[0]; #23
+            samples['hyvel_right'][cnt] = fd.fs.hyvel[1]; #24
+            samples['rxvel_left'][cnt] = fd.fs.rxvel[0]; #25
+            samples['rxvel_right'][cnt] = fd.fs.rxvel[1]; #26
+            samples['ryvel_left'][cnt] = fd.fs.ryvel[0]; #27
+            samples['ryvel_right'][cnt] = fd.fs.ryvel[1]; #28
+            
+            ## REV: These are all accessing 0th element for some reason
+            samples['fgxvel'][cnt] = fd.fs.fgxvel[0]; #29
+            samples['fgyvel'][cnt] = fd.fs.fgyvel[0]; #30
+            samples['fhxvel'][cnt] = fd.fs.fhxvel[0]; #31
+            samples['fhyvel'][cnt] = fd.fs.fhyvel[0]; #32
+            samples['frxvel'][cnt] = fd.fs.frxvel[0]; #33
+            samples['fryvel'][cnt] = fd.fs.fryvel[0]; #34
+            
+            samples['flags'][cnt] = fd.fs.flags; #35
+            samples['input'][cnt] = fd.fs.input; #36 # extra (input word)
+            samples['buttons'][cnt] = fd.fs.buttons  #37 # button state & changes
+            samples['htype'][cnt] = fd.fs.htype; #38  # head-tracker data type
+            samples['errors'][cnt] = fd.fs.errors; #39
 
-            samples[cnt, 17] = fd.fs.gxvel[0]
-            samples[cnt, 18] = fd.fs.gxvel[1]
-            samples[cnt, 19] = fd.fs.gyvel[0]
-            samples[cnt, 20] = fd.fs.gyvel[1]
-            samples[cnt, 21] = fd.fs.hxvel[0]
-            samples[cnt, 22] = fd.fs.hxvel[1]
-            samples[cnt, 23] = fd.fs.hyvel[0]
-            samples[cnt, 24] = fd.fs.hyvel[1]
-            samples[cnt, 25] = fd.fs.rxvel[0]
-            samples[cnt, 26] = fd.fs.rxvel[1]
-            samples[cnt, 27] = fd.fs.ryvel[0]
-            samples[cnt, 28] = fd.fs.ryvel[1]
-
-            samples[cnt, 29] = fd.fs.fgxvel[0]
-            samples[cnt, 30] = fd.fs.fgyvel[0]
-            samples[cnt, 31] = fd.fs.fhxvel[0]
-            samples[cnt, 32] = fd.fs.fhyvel[0]
-            samples[cnt, 33] = fd.fs.frxvel[0]
-            samples[cnt, 34] = fd.fs.fryvel[0]
-
-            # samples[cnt, 39:48] =  <float>fd.fs.hdata # head-tracker data
-            # (not prescaled)
-            samples[cnt, 35] = fd.fs.flags  # flags to indicate contents
-            samples[cnt, 36] = fd.fs.input  # extra (input word)
-            samples[cnt, 37] = fd.fs.buttons  # button state & changes
-            samples[cnt, 38] = fd.fs.htype  # head-tracker data type
-            samples[cnt, 39] = fd.fs.errors
-            cnt += 1
-
+            
+            '''
+            # REV: hdata Don't use for now (reserved for future...)
+            for i in range(8):
+                samples['hdata_{}'][cnt][i] = fd.fs.hdata[i];
+                pass;
+            '''
+            
+            cnt += 1;
+            pass;
+        
         elif sample_type == MESSAGEEVENT:
             data = data2dict(sample_type, ef)
             trial = parse_message(
@@ -335,5 +390,39 @@ def parse_edf(
     free(buf)
     # num_elements contained number of combined samples, messages, and events. This truncates
     # to only number of samples read (cnt).
-    samples = samples[:cnt, :];
+
+    
+    for key in samples:
+        #print("Reducing column [{}] from num_elements [={}] to cnt [={}]".format(key, num_elements, cnt));
+        samples[key] = samples[key][:cnt];
+        pass;
+    
     return samples, event_accumulator, message_accumulator
+
+
+
+#parse_edf = parse_edf_fltint_pydict;
+
+#REV: converts samples 'time' column from default uint32 to float64, with 0.5 msec offsets.
+def samples_to_ftime(samples):
+    """
+    Converts time column from uint32 to float64, and adds 0.5 for each with flags column
+    SAMPLE_ADD_OFFSET bit set true.
+
+    Input: pandas dataframe samples.
+
+    Output: Returns modified dataframe samples with time converted to float64, and with appropriate OFFSET
+    added.
+    """
+    bitmask = SAMPLE_ADD_OFFSET; #bitmask = 0x0002;
+    HALFMS=0.5; #unit is already MSEC for edf's "time".
+    if( samples['flags'].dtype != np.uint16 ):
+        raise Exception("ERROR: flags should be of unsigned integer type (expect uint16) for bitwise-AND to work properly. Found type: {}".format(samples['flags'].dtype));
+    samples['_halfms'] = (0 != (bitmask & samples['flags']));
+    samples['time'] = samples['time'].astype(np.float64);
+    samples.loc[ (True==samples['_halfms']), 'time' ] += HALFMS;
+    
+    # Drop temporary _halfms column
+    samples = samples[ [a for a in samples.columns if a is not '_halfms' ] ];
+    
+    return samples;

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -431,40 +431,33 @@ def samples_to_ftime(samples):
 
 ## REV: It *says* that all non-included values will be set to MISSING_DATA (-32000ish), but I do not see that, I see random noise.
 def sanitize_samples_by_flags(s):
-    s = s.reset_index(drop=True);
-    s['flags'] = s['flags'].astype(np.uint16);
+    s = s.copy().reset_index(drop=True);
     
+    s.loc[:, 'flags'] = s['flags'].astype(np.uint16);
+            
+        
     if( 'eye' in s.columns ):
         raise Exception("WTF eye already in samples");
-    s['eye'] = -1;
-    s['eye'] = s.eye.astype(np.int8);
+    s.loc[:, 'eye'] = -1;
+    s.loc[:, 'eye'] = s.eye.astype(np.int8);
     
     f = s['flags'];
-
+    
     #REV: "truth statements" dont work.
     s.loc[ (SAMPLE_LEFT & f) != 0, 'eye' ] = 0;
     s.loc[ (SAMPLE_RIGHT & f) != 0, 'eye' ] = 1;
     s.loc[ ((SAMPLE_LEFT & f) & (SAMPLE_RIGHT & s['flags'])) != 0 , 'eye' ] = 2; #2 for binoc i guess.
 
-    #print("VALUES");
-    #print( s[ s.eye == 0 ] );
-    #print( s[ s.eye == 1 ] );
-    #print( s[ s.eye == 2 ] );
     
-    #print("HELLO SIR");
-    #print(s.columns);
-    #exit(0);
-
     #REV: oh wait, it shares row...
     lcols=[ c for c in s.columns if '_left' in c ];
     rcols=[ c for c in s.columns if '_right' in c ];
-    
-    #print(lcols);
-    #print(rcols);
-    
+        
     
     s.loc[ (s.eye==0), rcols ] = np.nan;
     s.loc[ (s.eye==1), lcols ] = np.nan;
+
+    
     
     haspupilsize = 0 == (f & SAMPLE_PUPILSIZE);
     haspupilxy = 0 == (f & SAMPLE_PUPILXY);
@@ -511,4 +504,4 @@ def sanitize_samples_by_flags(s):
         #s[c] = vec_float_or_nan(s[c]);
         pass;
     
-    return s.copy();
+    return s;

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -431,15 +431,16 @@ def samples_to_ftime(samples):
 
 ## REV: It *says* that all non-included values will be set to MISSING_DATA (-32000ish), but I do not see that, I see random noise.
 def sanitize_samples_by_flags(s):
-    s = s.copy().reset_index(drop=True);
+    s = s.copy();
+    s = s.reset_index(drop=True);
     
-    s.loc[:, 'flags'] = s['flags'].astype(np.uint16);
+    s['flags'] = s['flags'].astype(np.uint16);
             
         
     if( 'eye' in s.columns ):
         raise Exception("WTF eye already in samples");
-    s.loc[:, 'eye'] = -1;
-    s.loc[:, 'eye'] = s.eye.astype(np.int8);
+    s['eye'] = -1;
+    s['eye'] = s.eye.astype(np.int8);
     
     f = s['flags'];
     

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -446,10 +446,10 @@ def sanitize_samples_by_flags(s):
     s.loc[ (SAMPLE_RIGHT & f) != 0, 'eye' ] = 1;
     s.loc[ ((SAMPLE_LEFT & f) & (SAMPLE_RIGHT & s['flags'])) != 0 , 'eye' ] = 2; #2 for binoc i guess.
 
-    print("VALUES");
-    print( s[ s.eye == 0 ] );
-    print( s[ s.eye == 1 ] );
-    print( s[ s.eye == 2 ] );
+    #print("VALUES");
+    #print( s[ s.eye == 0 ] );
+    #print( s[ s.eye == 1 ] );
+    #print( s[ s.eye == 2 ] );
     
     #print("HELLO SIR");
     #print(s.columns);
@@ -458,7 +458,7 @@ def sanitize_samples_by_flags(s):
     #REV: oh wait, it shares row...
     lcols=[ c for c in s.columns if '_left' in c ];
     rcols=[ c for c in s.columns if '_right' in c ];
-
+    
     #print(lcols);
     #print(rcols);
     

--- a/src/pyedfread/edf_read.pyx
+++ b/src/pyedfread/edf_read.pyx
@@ -447,18 +447,19 @@ def sanitize_samples_by_flags(s):
     #REV: "truth statements" dont work.
     s.loc[ (SAMPLE_LEFT & f) != 0, 'eye' ] = 0;
     s.loc[ (SAMPLE_RIGHT & f) != 0, 'eye' ] = 1;
-    s.loc[ ((SAMPLE_LEFT & f) & (SAMPLE_RIGHT & s['flags'])) != 0 , 'eye' ] = 2; #2 for binoc i guess.
-
+    s.loc[ ((SAMPLE_LEFT & f) & (SAMPLE_RIGHT & f)) != 0 , 'eye' ] = 2; #2 for binoc i guess.
+    
     
     #REV: oh wait, it shares row...
     lcols=[ c for c in s.columns if '_left' in c ];
     rcols=[ c for c in s.columns if '_right' in c ];
         
-    
-    s.loc[ (s.eye==0), rcols ] = np.nan;
-    s.loc[ (s.eye==1), lcols ] = np.nan;
 
-    
+    ## Delete right eye data if left eye recorded only
+    s.loc[ (s.eye==0), rcols ] = np.nan;
+
+    ## Delete left eye data if right eye recorded only
+    s.loc[ (s.eye==1), lcols ] = np.nan;
     
     haspupilsize = 0 == (f & SAMPLE_PUPILSIZE);
     haspupilxy = 0 == (f & SAMPLE_PUPILXY);

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -12,6 +12,7 @@ def read_edf(
     message_filter=None,
     trial_marker="TRIALID",
     ftime=True,
+    exclude_vel_cols=True,
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -40,10 +41,13 @@ def read_edf(
         Messages that start with this string will be assumed to
         indicate the start of a trial.
 
-    ftime : bool, optional
+    ftime : bool, optional (default True)
         Should return time column "time" as a floating point number with appropriate adjustments made (+0.5 msec) for
         samples with the appropriate flag set (for 2000 Hz sampling rate).
 
+    exclude_vel_cols : bool, optional (default True)
+        Temporary fix to exclude *vel* columns (actually sets values to NAN). fgxvel, gxvel_left, fgxvel_left, etc.
+    
     Returns
     -------
     samples : pandas.DataFrame
@@ -69,6 +73,11 @@ def read_edf(
     # by each row's "flag" column's bits.
     if( True == ftime ):
         samples = edf_read.samples_to_ftime(samples);
+        pass;
+
+    if( True == exclude_vel_cols ):
+        velcols=[ c for c in samples.columns if 'vel' in c ];
+        samples.loc[:, velcols] = np.nan;
         pass;
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -13,7 +13,6 @@ def read_edf(
     trial_marker="TRIALID",
     ftime=True,
     exclude_vel_cols=True,
-    upgrade_dtypes=False,
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -52,11 +51,6 @@ def read_edf(
         (linux version eyelink-edfapi/stable,now 4.2.1197.0 amd64) library which leads to memory corruption in values returend by
         edf.h edf_get_float_data()
 
-    upgrade_dtypes : bool, optional (default True)
-        Will convert from C-side (EDFAPI) types, e.g. native system float (usually float32), and int/uint16 to the largest (appropriate)
-        available python types, using pandas NaN-able types where appropriate. Effectively this just runs convert_dtypes() on the
-        samples dataframe before returning.
-    
     Returns
     -------
     samples : pandas.DataFrame
@@ -87,10 +81,6 @@ def read_edf(
     if( True == exclude_vel_cols ):
         velcols=[ c for c in samples.columns if 'vel' in c ];
         samples.loc[:, velcols] = np.nan;
-        pass;
-
-    if( True == upgrade_dtypes ):
-        samples = samples.convert_dtypes();
         pass;
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -11,6 +11,7 @@ def read_edf(
     ignore_samples=False,
     message_filter=None,
     trial_marker="TRIALID",
+    ftime=True,
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -39,6 +40,10 @@ def read_edf(
         Messages that start with this string will be assumed to
         indicate the start of a trial.
 
+    ftime : bool, optional
+        Should return time column "time" as a floating point number with appropriate adjustments made (+0.5 msec) for
+        samples with the appropriate flag set (for 2000 Hz sampling rate).
+
     Returns
     -------
     samples : pandas.DataFrame
@@ -58,7 +63,17 @@ def read_edf(
     )
     events = pd.DataFrame(events)
     messages = pd.DataFrame(messages)
-    samples = pd.DataFrame(np.asarray(samples), columns=edf_read.sample_columns)
+    samples = pd.DataFrame(samples)
+
+    # if ftime option is set, convert time column to float and add 0.5 msec offsets if required
+    # by each row's "flag" column's bits.
+    if( True == ftime ):
+        samples = edf_read.samples_to_ftime(samples);
+        pass;
+    
+    ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)
+    samples = samples[ list(edf_read.sample_columns) ];
+    
     return samples, events, messages
 
 

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -13,6 +13,7 @@ def read_edf(
     trial_marker="TRIALID",
     ftime=True,
     exclude_vel_cols=True,
+    upgrade_dtypes=False,
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -46,7 +47,15 @@ def read_edf(
         samples with the appropriate flag set (for 2000 Hz sampling rate).
 
     exclude_vel_cols : bool, optional (default True)
-        Temporary fix to exclude *vel* columns (actually sets values to NAN). fgxvel, gxvel_left, fgxvel_left, etc.
+        (Hopefully temporary) fix to exclude *vel* columns (actually sets values to NAN). fgxvel, gxvel_left, fgxvel_left, etc. all
+        columns containing "vel" in their string are set to NaN to avoid a seeming bug in the
+        (linux version eyelink-edfapi/stable,now 4.2.1197.0 amd64) library which leads to memory corruption in values returend by
+        edf.h edf_get_float_data()
+
+    upgrade_dtypes : bool, optional (default True)
+        Will convert from C-side (EDFAPI) types, e.g. native system float (usually float32), and int/uint16 to the largest (appropriate)
+        available python types, using pandas NaN-able types where appropriate. Effectively this just runs convert_dtypes() on the
+        samples dataframe before returning.
     
     Returns
     -------
@@ -78,6 +87,10 @@ def read_edf(
     if( True == exclude_vel_cols ):
         velcols=[ c for c in samples.columns if 'vel' in c ];
         samples.loc[:, velcols] = np.nan;
+        pass;
+
+    if( True == upgrade_dtypes ):
+        samples = samples.convert_dtypes();
         pass;
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -12,7 +12,7 @@ def read_edf(
     message_filter=None,
     trial_marker="TRIALID",
     ftime=True,
-    exclude_vel_cols=True,
+    exclude_vel_cols=False,
 ):
     """
     Parse an EDF file into a pandas.DataFrame.
@@ -77,7 +77,7 @@ def read_edf(
     if( True == ftime ):
         samples = edf_read.samples_to_ftime(samples);
         pass;
-
+    
     if( True == exclude_vel_cols ):
         velcols=[ c for c in samples.columns if 'vel' in c ];
         samples.loc[:, velcols] = np.nan;
@@ -85,6 +85,8 @@ def read_edf(
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)
     samples = samples[ list(edf_read.sample_columns) ];
+
+    samples = edf_read.sanitize_samples_by_flags(samples);
     
     return samples, events, messages
 

--- a/src/pyedfread/parse.py
+++ b/src/pyedfread/parse.py
@@ -85,9 +85,9 @@ def read_edf(
     
     ## Reorder samples column to be in same order as previously (based on FSAMPLE struct)
     samples = samples[ list(edf_read.sample_columns) ];
-
-    samples = edf_read.sanitize_samples_by_flags(samples);
     
+    samples = edf_read.sanitize_samples_by_flags(samples);
+        
     return samples, events, messages
 
 

--- a/tests/R_sanity/edf2csv.R
+++ b/tests/R_sanity/edf2csv.R
@@ -1,0 +1,8 @@
+
+library(eyelinkReader)
+args <- commandArgs(trailingOnly = TRUE)
+fn = args[1];
+tag = args[2];
+gaze <- read_edf(fn, import_samples=TRUE);
+outfn = paste('df', string(tag), '.csv', sep='');
+write.csv(gaze$samples, outfn);

--- a/tests/py_sanity/compare_dfs.py
+++ b/tests/py_sanity/compare_dfs.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import numpy as np
+import sys;
+
+dfs=list();
+fns=list();
+for a in sys.argv[1:]:
+    fns.append(a);
+    df=pd.read_csv(a);
+    df = df[ [c for c in df.columns if c!='eye'] ];
+    dfs.append( df);
+    pass;
+#df1 = pd.read_csv('test1')
+#df2 = pd.read_csv('test2')
+
+#for c in df1.columns:
+#    np.isclose( df1[c], df2[c] ) == False
+
+
+for i,df1 in enumerate(dfs):
+    for j,df2 in enumerate(dfs):
+        if( j >= i ):
+            # skip lower triangle (redundant)
+            continue;
+        print("COMPARING: ", fns[i], fns[j]);
+        
+        if( list(df1.columns) != list(df2.columns) ):
+            print(fns[i], fns[j]);
+            raise Exception("COLUMNS not equal!");
+        
+        for c in df1.columns:
+            closerows = np.isclose( df1[c], df2[c] ) | (np.isnan(df1[c]) & np.isnan(df2[c]) );
+            if( np.any(
+                    closerows == False
+            )
+               ):
+                badrows = ~closerows;
+                nbad = np.sum(badrows);
+                print("[{} - {}]  --   Column {} fails ({}/{} bad)".format(fns[i], fns[j], c, nbad, len(df1.index)));
+                
+                bad1 = df1[ badrows ][c];
+                bad2 = df2[ badrows ][c];
+                #for x,y in zip(bad1, bad2):
+                #    print("{} <-> {}".format(x,y));
+                #    pass;
+                pass;
+            pass;
+        pass;
+    pass;

--- a/tests/py_sanity/edfs_to_csvs.py
+++ b/tests/py_sanity/edfs_to_csvs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+'''
+
+Simple script which loads an EDF filename from command line
+argument and saves samples, messages, events as named csvs.
+Writes to same path as input .edf file with appended .samples.csv or
+.events.csv or .messages.csv.
+
+'''
+
+def main():
+    import sys
+    import pandas as pd
+    import pyedfread
+    import numpy as np
+    if( len(sys.argv) != 3 ):
+        print("Usage: [THISSCRIPT] [EDFFILEPATH] [NROWS]");
+        return 1;
+    
+    incsvpath = sys.argv[1];
+    nrows = int(sys.argv[2]);
+    sampdf, evtdf, msgdf = pyedfread.read_edf( incsvpath );
+    
+    sampdf = sampdf.iloc[ :nrows ];
+    # Just to make saving smaller, only save 5000 samples
+    #if( len(sampdf.index) > 10000 ):
+        # For np r_: https://stackoverflow.com/questions/39393856/python-pandas-slice-dataframe-by-multiple-index-ranges
+    #    sampdf = sampdf.iloc[np.r_[:5000, -5000:]];
+    #    pass;
+    
+    sampdf.to_csv( incsvpath + '.samples.csv', index=False );
+    evtdf.to_csv( incsvpath + '.events.csv', index=False );
+    msgdf.to_csv( incsvpath + '.messages.csv', index=False );
+        
+    return 0;
+
+
+if __name__=='__main__':
+    exit( main() );
+    pass;

--- a/tests/py_sanity/sanity_test_reproducibility.py
+++ b/tests/py_sanity/sanity_test_reproducibility.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import numpy as np
+import sys;
+import time;
+import pyedfread;
+
+## Why would values change between "runs" (i.e. different process) and "repeats" in same process?
+## Probably due to memory mapping etc., of the loaded EDFAPI library, when it is loaded in (dynamically?).
+dfs=list();
+NTRIES=3;
+for n in range(NTRIES):
+    s, e, m = pyedfread.read_edf( sys.argv[1] ) ;
+    dfs.append(s);
+    import pyedfread
+    #time.sleep(30);
+    pass;
+
+tag = str(sys.argv[2]);
+
+csvfns=list();
+for i,df1 in enumerate(dfs):
+    fn = '{}_df{}.csv'.format(tag,i);
+    csvfns.append(fn);
+    df1.to_csv(fn, index=False);
+    for j,df2 in enumerate(dfs):
+        if( j >= i ):
+            # skip lower triangle (redundant)
+            continue;
+        
+        if( list(df1.columns) != list(df2.columns) ):
+            #print(fns[i], fns[j]);
+            raise Exception("COLUMNS not equal!");
+        
+        for c in df1.columns:
+            closerows = np.isclose( df1[c], df2[c] ) | (np.isnan(df1[c]) & np.isnan(df2[c]) );
+            if( np.any(
+                    closerows == False
+            )
+               ):
+                print("[{} - {}]  --   Column {} fails".format(i, j, c));
+                pass;
+            pass;
+        pass;
+    pass;
+
+print("SUCCEEDED in memory, now CSV");
+
+dfs = list();
+for fn in csvfns:
+    s = pd.read_csv(fn);
+    dfs.append(s);
+    pass;
+
+for i,df1 in enumerate(dfs):
+    for j,df2 in enumerate(dfs):
+        if( j >= i ):
+            # skip lower triangle (redundant)
+            continue;
+        
+        if( list(df1.columns) != list(df2.columns) ):
+            print("FAIL COLUMN", fns[i], fns[j]);
+            raise Exception("COLUMNS not equal!");
+        
+        for c in df1.columns:
+            closerows = np.isclose( df1[c], df2[c] ) | (np.isnan(df1[c]) & np.isnan(df2[c]) );
+            if( np.any(
+                    closerows == False
+            )
+               ):
+                print("[{} - {}]  --   Column {} fails".format(fns[i], fns[j], c));
+                pass;
+            pass;
+        pass;
+    pass;


### PR DESCRIPTION
This does several things:

1) clarifies the meaning of the various sample columns while they are being read in edf_read.py from the edf_get_float_data() by reading them into a separate Nx1 array linked to the column name key in a dictionary rather than an NxC numpy ndarray. dtypes are the native dtypes returned by the FSAMPLE struct, rather than the all-float version previously returned. One can afterwards run "convert_dtypes" to convert to more robust datatypes if necessary.
2) fixes the number_elements problem (already fixed in main, but necessary to fix again if reading method is changed) by resizing each of the Nx1 arrays to the number of samples read.
3) Adds an "exclude_vel_cols" option in parse() to read_edf, default True, which sets all velocity-related sample columns to NaN. Does not effect events. This is to temporarily address the seeming memory uninitialization/struct offset error (cause uncertain) observed in linux version 4.2.1197 at least. I am not sure how to add "tests" for this in pytest since it requries running multiple processes and is nondeterministic... I added several directories to the tests/ directories which contain python scripts to check this (in R using eyelinkReader, and python using pyedfread)
4) Adds an "ftime" option to read_edf, which converts the "Time" column to floating point (from default uint32) and adds 0.5 seconds for appropriate rows based on flag. I suppose I need to add a test for this, which requires adding an EDF file recorded at 2000 Hz and a way of identifying what is correct (via e.g. ASC from edf2asc). I will prepare this later...